### PR TITLE
fix(NetworkCakeShop) CategoryDetailViewModel 수정

### DIFF
--- a/Projects/Feature/CakeShop/Sources/Scene/CategoryDetailViewModel.swift
+++ b/Projects/Feature/CakeShop/Sources/Scene/CategoryDetailViewModel.swift
@@ -63,6 +63,7 @@ public final class CategoryDetailViewModel: ObservableObject {
     
     // 기존에 진행중이던 작업 취소
     currentFetchCancellable?.cancel()
+    currentFetchMoreCancellable?.cancel()
     
     currentFetchCancellable = useCase.execute(category: category, count: 10, lastCakeId: nil)
       .subscribe(on: DispatchQueue.global())


### PR DESCRIPTION
- 새로운 카테고리의 CakeImage를 불러올 때 fetchMore 하던 작업도 같이 취소되도록 변경