### PR TITLE
style(*) init 코드 스타일 변경

### DIFF
--- a/Projects/Core/Data/Network/User/Sources/UseCases/SocialLoginSignInUseCaseImpl.swift
+++ b/Projects/Core/Data/Network/User/Sources/UseCases/SocialLoginSignInUseCaseImpl.swift
@@ -21,8 +21,10 @@ public final class SocialLoginSignInUseCaseImpl: SocialLoginSignInUseCase {
   
   // MARK: - Initializers
   
-  public init(socialLoginRepository: SocialLoginRepository,
-              userSession: UserSession) {
+  public init(
+    socialLoginRepository: SocialLoginRepository,
+    userSession: UserSession) 
+  {
     self.repository = socialLoginRepository
     self.userSession = userSession
   }

--- a/Projects/Core/Data/Network/User/Sources/UseCases/SocialLoginSignUpUseCaseImpl.swift
+++ b/Projects/Core/Data/Network/User/Sources/UseCases/SocialLoginSignUpUseCaseImpl.swift
@@ -22,8 +22,10 @@ public final class SocialLoginSignUpUseCaseImpl: SocialLoginSignUpUseCase {
   
   // MARK: - Initializers
   
-  public init(socialLoginRepository: SocialLoginRepository,
-              userSession: UserSession) {
+  public init(
+    socialLoginRepository: SocialLoginRepository,
+    userSession: UserSession) 
+  {
     self.socialLoginRepository = socialLoginRepository
     self.userSession = userSession
   }

--- a/Projects/Core/Domain/CakeShop/Sources/Entity/CakeImage.swift
+++ b/Projects/Core/Domain/CakeShop/Sources/Entity/CakeImage.swift
@@ -13,7 +13,11 @@ public struct CakeImage: Decodable, Identifiable {
   public let shopId: Int
   public let imageUrl: String
   
-  public init(id: Int, shopId: Int, imageUrl: String) {
+  public init(
+    id: Int,
+    shopId: Int,
+    imageUrl: String)
+  {
     self.id = id
     self.shopId = shopId
     self.imageUrl = imageUrl

--- a/Projects/Core/Domain/User/Sources/Entity/AuthData.swift
+++ b/Projects/Core/Domain/User/Sources/Entity/AuthData.swift
@@ -17,7 +17,15 @@ public struct AuthData {
   public var birthday: Date
   public var gender: Gender
   
-  public init(provider: LoginProvider, idToken: String, deviceToken: String? = nil, nickname: String, email: String, birthday: Date, gender: Gender) {
+  public init(
+    provider: LoginProvider,
+    idToken: String,
+    deviceToken: String? = nil,
+    nickname: String,
+    email: String,
+    birthday: Date,
+    gender: Gender)
+  {
     self.provider = provider
     self.idToken = idToken
     self.deviceToken = deviceToken

--- a/Projects/Core/Domain/User/Sources/Entity/CredentialData.swift
+++ b/Projects/Core/Domain/User/Sources/Entity/CredentialData.swift
@@ -12,7 +12,11 @@ public struct CredentialData {
   public var idToken: String
   public var deviceToken: String?
   
-  public init(loginProvider: LoginProvider, idToken: String, deviceToken: String? = nil) {
+  public init(
+    loginProvider: LoginProvider,
+    idToken: String,
+    deviceToken: String? = nil)
+  {
     self.loginProvider = loginProvider
     self.idToken = idToken
     self.deviceToken = deviceToken

--- a/Projects/Core/Domain/User/Sources/Entity/UserData.swift
+++ b/Projects/Core/Domain/User/Sources/Entity/UserData.swift
@@ -13,7 +13,12 @@ public struct UserData: Codable {
   public var birthday: Date
   public var gender: Gender
   
-  public init(nickname: String, email: String, birthday: Date, gender: Gender) {
+  public init(
+    nickname: String,
+    email: String,
+    birthday: Date,
+    gender: Gender)
+  {
     self.nickname = nickname
     self.email = email
     self.birthday = birthday

--- a/Projects/Core/Domain/User/Sources/Response/SocialLoginResponse.swift
+++ b/Projects/Core/Domain/User/Sources/Response/SocialLoginResponse.swift
@@ -12,7 +12,10 @@ public struct SocialLoginResponse {
   public let accessToken: String
   public let refreshToken: String
   
-  public init(accessToken: String, refreshToken: String) {
+  public init(
+    accessToken: String,
+    refreshToken: String)
+  {
     self.accessToken = accessToken
     self.refreshToken = refreshToken
   }

--- a/Projects/DesignSystem/Sources/Components/Button/CKButtonCompact.swift
+++ b/Projects/DesignSystem/Sources/Components/Button/CKButtonCompact.swift
@@ -19,9 +19,11 @@ public struct CKButtonCompact: View {
   
   // MARK: - Initializers
   
-  public init(title: String, 
-              fixedSize: CGFloat? = nil,
-              action: (() -> Void)? = nil) {
+  public init(
+    title: String,
+    fixedSize: CGFloat? = nil,
+    action: (() -> Void)? = nil)
+  {
     self.title = title
     self.action = action
     self.fixedSize = fixedSize

--- a/Projects/DesignSystem/Sources/Components/Button/CKButtonLarge.swift
+++ b/Projects/DesignSystem/Sources/Components/Button/CKButtonLarge.swift
@@ -19,9 +19,11 @@ public struct CKButtonLarge: View {
   
   // MARK: - Initializers
   
-  public init(title: String,
-              fixedSize: CGFloat? = nil,
-              action: (() -> Void)? = nil) {
+  public init(
+    title: String,
+    fixedSize: CGFloat? = nil,
+    action: (() -> Void)? = nil
+  ) {
     self.title = title
     self.action = action
     self.fixedSize = fixedSize

--- a/Projects/DesignSystem/Sources/Components/Button/CKButtonLargeMessage.swift
+++ b/Projects/DesignSystem/Sources/Components/Button/CKButtonLargeMessage.swift
@@ -20,10 +20,12 @@ public struct CKButtonLargeMessage: View {
   
   // MARK: - Initializers
   
-  public init(title: String,
-              message: String,
-              fixedSize: CGFloat? = nil,
-              action: (() -> Void)? = nil) {
+  public init(
+    title: String,
+    message: String,
+    fixedSize: CGFloat? = nil,
+    action: (() -> Void)? = nil) 
+  {
     self.title = title
     self.message = message
     self.action = action

--- a/Projects/DesignSystem/Sources/Components/Button/CKButtonLargeStroked.swift
+++ b/Projects/DesignSystem/Sources/Components/Button/CKButtonLargeStroked.swift
@@ -19,9 +19,11 @@ public struct CKButtonLargeStroked: View {
   
   // MARK: - Initializers
   
-  public init(title: String,
-              fixedSize: CGFloat? = nil,
-              action: (() -> Void)? = nil) {
+  public init(
+    title: String,
+    fixedSize: CGFloat? = nil,
+    action: (() -> Void)? = nil) 
+  {
     self.title = title
     self.action = action
     self.fixedSize = fixedSize

--- a/Projects/DesignSystem/Sources/Components/Button/CKButtonRegular.swift
+++ b/Projects/DesignSystem/Sources/Components/Button/CKButtonRegular.swift
@@ -19,9 +19,11 @@ public struct CKButtonRegular: View {
   
   // MARK: - Initializers
   
-  public init(title: String,
-              fixedSize: CGFloat? = nil,
-              action: (() -> Void)? = nil) {
+  public init(
+    title: String,
+    fixedSize: CGFloat? = nil,
+    action: (() -> Void)? = nil)
+  {
     self.title = title
     self.action = action
     self.fixedSize = fixedSize

--- a/Projects/DesignSystem/Sources/Components/DialogView.swift
+++ b/Projects/DesignSystem/Sources/Components/DialogView.swift
@@ -24,12 +24,14 @@ public struct DialogView: View {
   
   // MARK: - Initializers
   
-  public init(title: String, 
-              message: String = "",
-              primaryButtonTitle: String,
-              primaryButtonAction: @escaping () -> Void,
-              secondaryButtonTitle: String? = nil,
-              secondaryButtonAction: (() -> Void)? = nil) {
+  public init(
+    title: String,
+    message: String = "",
+    primaryButtonTitle: String,
+    primaryButtonAction: @escaping () -> Void,
+    secondaryButtonTitle: String? = nil,
+    secondaryButtonAction: (() -> Void)? = nil) 
+  {
     self.title = title
     self.message = message
     self.primaryButtonTitle = primaryButtonTitle

--- a/Projects/DesignSystem/Sources/Components/StepNavigationView.swift
+++ b/Projects/DesignSystem/Sources/Components/StepNavigationView.swift
@@ -19,7 +19,10 @@ public struct StepNavigationView: View {
   
   // MARK: - Initializers
   
-  public init(title: String, onTapBackButton: (() -> Void)? = nil) {
+  public init(
+    title: String,
+    onTapBackButton: (() -> Void)? = nil)
+  {
     self.title = title
     self.onTapBackButton = onTapBackButton
   }

--- a/Projects/DesignSystem/Sources/Views/FailureStateView.swift
+++ b/Projects/DesignSystem/Sources/Views/FailureStateView.swift
@@ -20,10 +20,12 @@ public struct FailureStateView: View {
   
   // MARK: - Initializers
   
-  public init(title: String,
-       buttonTitle: String? = nil,
-       buttonAction: (() -> Void)? = nil,
-       buttonDescription: String? = nil) {
+  public init(
+    title: String,
+    buttonTitle: String? = nil,
+    buttonAction: (() -> Void)? = nil,
+    buttonDescription: String? = nil) 
+  {
     self.title = title
     self.buttonTitle = buttonTitle
     self.buttonAction = buttonAction

--- a/Projects/DesignSystem/Sources/Views/FlexibleGridView.swift
+++ b/Projects/DesignSystem/Sources/Views/FlexibleGridView.swift
@@ -24,7 +24,13 @@ public struct FlexibleGridView<Data: RandomAccessCollection, Content: View>: Vie
   
   // MARK: - Initializers
   
-  public init(columns: Int = 2, verticalSpacing: CGFloat = 8, horizontalSpacing: CGFloat = 8, data: Data, @ViewBuilder content: @escaping (Data.Element) -> Content) {
+  public init(
+    columns: Int = 2,
+    verticalSpacing: CGFloat = 8,
+    horizontalSpacing: CGFloat = 8,
+    data: Data,
+    @ViewBuilder content: @escaping (Data.Element) -> Content)
+  {
     self.columns = columns
     self.verticalSpacing = verticalSpacing
     self.horizontalSpacing = horizontalSpacing

--- a/Projects/Feature/CakeShop/Sources/Scene/CategoryDetailViewModel.swift
+++ b/Projects/Feature/CakeShop/Sources/Scene/CategoryDetailViewModel.swift
@@ -46,7 +46,10 @@ public final class CategoryDetailViewModel: ObservableObject {
   
   // MARK: - Initializers
   
-  public init(initialCategory: CakeCategory, diContainer: DIContainerProtocol) {
+  public init(
+    initialCategory: CakeCategory,
+    diContainer: DIContainerProtocol)
+  {
     _category = .init(initialValue: initialCategory)
     self.diContainer = diContainer
     self.useCase = diContainer.resolve(CakeImagesByCategoryUseCase.self)!

--- a/Projects/Feature/Router/Sources/StepRouter.swift
+++ b/Projects/Feature/Router/Sources/StepRouter.swift
@@ -21,7 +21,11 @@ public class StepRouter: ObservableObject {
   
   // MARK: - Initializers
   
-  public init(steps: [AnyView], parentCoordinator: StepRouter? = nil, onFinish: (() -> Void)? = nil) {
+  public init(
+    steps: [AnyView],
+    parentCoordinator: StepRouter? = nil,
+    onFinish: (() -> Void)? = nil)
+  {
     self.steps = steps
     self.parentCoordinator = parentCoordinator
     self.onFinish = onFinish

--- a/Projects/Feature/User/Sources/Coordinator/LoginStepCoordinator.swift
+++ b/Projects/Feature/User/Sources/Coordinator/LoginStepCoordinator.swift
@@ -41,8 +41,10 @@ public struct LoginStepCoordinator: View {
   
   // MARK: - Initializers
   
-  public init(diContainer: DIContainerProtocol,
-              onFinish: @escaping () -> Void) {
+  public init(
+    diContainer: DIContainerProtocol,
+    onFinish: @escaping () -> Void) 
+  {
     self.diContainer = diContainer
     _stepRouter = .init(wrappedValue: StepRouter(steps: [AnyView(Login_Root())], onFinish: onFinish))
     _socialLoginViewModel = .init(wrappedValue: diContainer.resolve(SocialLoginViewModel.self)!)

--- a/Projects/Feature/User/Sources/Coordinator/SignUpCoordinator.swift
+++ b/Projects/Feature/User/Sources/Coordinator/SignUpCoordinator.swift
@@ -30,8 +30,10 @@ public struct SignUpStepCoordinator: View {
   
   // MARK: - Initializers
   
-  public init(containsEmailInput: Bool = false,
-              onFinish: @escaping () -> Void) {
+  public init(
+    containsEmailInput: Bool = false,
+    onFinish: @escaping () -> Void)
+  {
     if containsEmailInput {
       _coordinator = .init(wrappedValue: StepRouter(steps: [
         AnyView(SignUp_Email()),


### PR DESCRIPTION
- 파라미터명이 길거나 파라미터 타입이 길고 ViewBuilder, escaping 등 파라미터 앞에 많은 옵션이 들어가는 경우 더 나은 가독성을 위해
- 두 개 이상의 파라미터를 가진 initializer의 경우 다음과 같은 형식으로 initializer를 통일
```Swift
init(
  aParam: Type,
  bParam: Type
) {
  ...
}
```