### PR TITLE
fix(*) PhotoPicker ignoreSafeArea 적용

### DIFF
--- a/Projects/Feature/CakeShopAdmin/Feature/Sources/Scene/EditCakeShopBasicInfoView.swift
+++ b/Projects/Feature/CakeShopAdmin/Feature/Sources/Scene/EditCakeShopBasicInfoView.swift
@@ -217,6 +217,7 @@ public struct EditCakeShopBasicInfoView: View {
                   viewModel.editedBasicInfo.profileImage = .new(image: image)
                 }
               }))
+              .ignoresSafeArea()
             }
           }
         }

--- a/Projects/Feature/CakeShopAdmin/Feature/Sources/Scene/NewCakeImageView.swift
+++ b/Projects/Feature/CakeShopAdmin/Feature/Sources/Scene/NewCakeImageView.swift
@@ -213,6 +213,7 @@ public struct NewCakeImageView: View {
     }
     .sheet(isPresented: $isPhotoPickerShown) {
       PhotoPicker(selectedImage: $viewModel.cakeImage)
+        .ignoresSafeArea()
     }
     .onReceive(viewModel.$imageUploadingState, perform: { uploadState in
       switch uploadState {

--- a/Projects/Feature/User/Feature/Sources/Scene/BusinessCertificationView.swift
+++ b/Projects/Feature/User/Feature/Sources/Scene/BusinessCertificationView.swift
@@ -181,6 +181,7 @@ public struct BusinessCertificationView: View {
       .padding(.horizontal, 24)
       .sheet(isPresented: $isBusinessCertPhotoPickerShown, content: {
         PhotoPicker(selectedImage: $viewModel.selectedBusinessCertImage)
+          .ignoresSafeArea()
       })
     }
   }
@@ -229,6 +230,7 @@ public struct BusinessCertificationView: View {
       .padding(.horizontal, 24)
       .sheet(isPresented: $isIdCardPhotoPickerShown, content: {
         PhotoPicker(selectedImage: $viewModel.selectedIdCardImage)
+          .ignoresSafeArea()
       })
     }
   }

--- a/Projects/Feature/User/Feature/Sources/Scene/Profile/EditProfileView.swift
+++ b/Projects/Feature/User/Feature/Sources/Scene/Profile/EditProfileView.swift
@@ -152,6 +152,7 @@ struct EditProfileView: View {
                           viewModel.editedUserProfile.profileImage = .new(image: image)
                         }
                       }))
+                      .ignoresSafeArea()
                     }
                   }
                 }


### PR DESCRIPTION
- 기존 PhotoPicker가 bottom safeArea를 respect 하고있었음
- ignoreSafeArea() 를 통해서 하단 safeArea 무시