### PR TITLE
Rename | - | SocialLoginViewModel 이름 변경

### DIFF
--- a/Projects/Feature/User/Feature/Sources/RouteBuilder/LoginRouteBuilder.swift
+++ b/Projects/Feature/User/Feature/Sources/RouteBuilder/LoginRouteBuilder.swift
@@ -23,7 +23,7 @@ public struct LoginRouteBuilder: RouteBuilder {
   public var build: (LinkNavigatorType, [String: String], DependencyType) -> MatchingViewController? {
     { navigator, items, dependency in
       let container = DIContainer.shared.container
-      container.register(SocialLoginViewModel.self) { resolver in
+      container.register(SocialLoginSignInViewModel.self) { resolver in
         let signInUseCase = resolver.resolve(SocialLoginSignInUseCase.self)!
         return .init(signInUseCase: signInUseCase)
       }

--- a/Projects/Feature/User/Feature/Sources/Scene/SignIn/Login_Root.swift
+++ b/Projects/Feature/User/Feature/Sources/Scene/SignIn/Login_Root.swift
@@ -19,7 +19,7 @@ struct Login_Root: View {
 
   // MARK: - Properties
 
-  @StateObject private var viewModel: SocialLoginViewModel
+  @StateObject private var viewModel: SocialLoginSignInViewModel
 
   @State private var isShowing = false
   @State private var isShowingAppleSignInExpiredAlert = false
@@ -43,7 +43,7 @@ struct Login_Root: View {
   public init() {
     let diContainer = DIContainer.shared.container
     
-    _viewModel = .init(wrappedValue: diContainer.resolve(SocialLoginViewModel.self)!)
+    _viewModel = .init(wrappedValue: diContainer.resolve(SocialLoginSignInViewModel.self)!)
     
     self.analytics = diContainer.resolve(AnalyticsService.self)
     self.navigator = diContainer.resolve(LinkNavigatorType.self)
@@ -227,10 +227,10 @@ import PreviewSupportUser
 import DomainUser
 
 private struct PreviewContent: View {
-  @StateObject var viewModel: SocialLoginViewModel
+  @StateObject var viewModel: SocialLoginSignInViewModel
 
   init() {
-    let viewModel = SocialLoginViewModel(signInUseCase: MockSocialLoginSignInUseCase())
+    let viewModel = SocialLoginSignInViewModel(signInUseCase: MockSocialLoginSignInUseCase())
     _viewModel = .init(wrappedValue: viewModel)
   }
 

--- a/Projects/Feature/User/Feature/Sources/ViewModel/SocialLoginViewModel.swift
+++ b/Projects/Feature/User/Feature/Sources/ViewModel/SocialLoginViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  SocialLoginViewModel.swift
+//  SocialLoginSignInViewModel.swift
 //  CAKK
 //
 //  Created by 이승기 on 5/13/24.
@@ -21,7 +21,7 @@ import Logger
 import DIContainer
 import AnalyticsService
 
-public final class SocialLoginViewModel: NSObject, ObservableObject {
+public final class SocialLoginSignInViewModel: NSObject, ObservableObject {
   
   // MARK: - Properties
   
@@ -80,7 +80,7 @@ public final class SocialLoginViewModel: NSObject, ObservableObject {
 
 // MARK: - Google SignIn
 
-extension SocialLoginViewModel {
+extension SocialLoginSignInViewModel {
   public func signInWithGoogle() {
     Loggers.featureUser.info("구글 로그인에 시도합니다.", category: .network)
     guard let presentingViewController = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first?.rootViewController else { return }
@@ -150,7 +150,7 @@ extension SocialLoginViewModel {
 
 // MARK: - KaKao SignIn
 
-extension SocialLoginViewModel {
+extension SocialLoginSignInViewModel {
   public func signInWithKakao() {
     Loggers.featureUser.info("카카오 로그인에 시도합니다.", category: .network)
     signInState = .loading
@@ -281,7 +281,7 @@ extension SocialLoginViewModel {
 
 // MARK: - Apple SignIn
 
-extension SocialLoginViewModel: ASAuthorizationControllerDelegate {
+extension SocialLoginSignInViewModel: ASAuthorizationControllerDelegate {
   public func signInWithApple() {
     Loggers.featureUser.info("애플 로그인에 시도합니다.", category: .network)
     signInState = .loading

--- a/Projects/iOS_App/Sources/Assembly/FeatureUserAssembly.swift
+++ b/Projects/iOS_App/Sources/Assembly/FeatureUserAssembly.swift
@@ -48,9 +48,9 @@ final class FeatureUserAssembly: Assembly {
       return SocialLoginSignOutUseCaseImpl(socialLoginRepository: repository)
     }
     
-    container.register(SocialLoginViewModel.self) { resolver in
+    container.register(SocialLoginSignInViewModel.self) { resolver in
       let signInUseCase = resolver.resolve(SocialLoginSignInUseCase.self)!
-      return SocialLoginViewModel(signInUseCase: signInUseCase)
+      return SocialLoginSignInViewModel(signInUseCase: signInUseCase)
     }.inObjectScope(.transient)
     
     container.register(UserProfileRepository.self) { resolver in


### PR DESCRIPTION
- SignUpViewModel과의 혼동을 피하기 위해서 SocialLoginViewModel에서 SocialLoginSignInViewModel로 이름을 변경하였습니다.